### PR TITLE
Make sure numCentroids value is sane

### DIFF
--- a/serialization.go
+++ b/serialization.go
@@ -86,6 +86,10 @@ func FromBytes(buf *bytes.Reader) (*TDigest, error) {
 		return nil, err
 	}
 
+	if numCentroids < 0 || numCentroids > 1<<22 {
+		return nil, errors.New("bad number of centroids in serialization")
+	}
+
 	means := make([]float32, numCentroids)
 	var i int32
 	for i = 0; i < numCentroids; i++ {


### PR DESCRIPTION
Fixes a crash if numCentroids was negative, and potential out-of-memory
condition if we try to allocate to huge a digest.

And 4 million centroids ought to be enough for anybody...

Found by fuzzing.