### PR TITLE
Ensure returned values stay within bounds

### DIFF
--- a/tdigest.go
+++ b/tdigest.go
@@ -83,7 +83,9 @@ func (t *TDigest) Quantile(q float64) float64 {
 	})
 
 	if found {
-		return result
+		min := t.summary.keys[0]
+		max := t.summary.keys[len(t.summary.keys)-1]
+		return math.Min(max, math.Max(result, min))
 	}
 	return t.summary.Max().mean
 }

--- a/tdigest_test.go
+++ b/tdigest_test.go
@@ -200,6 +200,25 @@ func TestNonSequentialInsertion(t *testing.T) {
 	}
 }
 
+func TestRespectBounds(t *testing.T) {
+	tdigest := New(10)
+
+	data := []float64{0, 279, 2, 281}
+	for _, f := range data {
+		tdigest.Add(f, 1)
+	}
+
+	quantiles := []float64{0.01, 0.25, 0.5, 0.75, 0.999}
+	for _, q := range quantiles {
+		if tdigest.Quantile(q) < 0 {
+			t.Errorf("should never return a result less than the min")
+		}
+		if tdigest.Quantile(q) > 281 {
+			t.Errorf("should never return a result larger than the max")
+		}
+	}
+}
+
 func TestWeights(t *testing.T) {
 	tdigest := New(10)
 


### PR DESCRIPTION
While it's understandable for t-digests to be inaccurate on small sample sizes, the values returned should still be **within reason** and not impossible. This change clamps returned values to the range of keys seen.