### PR TITLE
Removed unnecessary swap and redundant sum operation

### DIFF
--- a/tdigest.go
+++ b/tdigest.go
@@ -117,10 +117,7 @@ func (t *TDigest) Quantile(q float64) float64 {
 }
 
 func weightedAverage(x1 float64, w1 float64, x2 float64, w2 float64) float64 {
-	if x1 > x2 {
-		x1, x2, w1, w2 = x2, x1, w2, w1
-	}
-	return x1*w1/(w1+w2) + x2*w2/(w1+w2)
+	return (x1*w1 + x2*w2)/(w1+w2)
 }
 
 // AddWeighted registers a new sample in the digest.


### PR DESCRIPTION
This change is mainly for code clarity and gives a slight performance increase. 

Removed swap operation of values and weights. Function arguments
are passed in as values so swap will make no changes. Swap also
does not alter result of weightedAverage calculation.

Also removed the redundant sum operation in the denominator.

[after_weightedAverage.txt](https://github.com/caio/go-tdigest/files/2236024/after_weightedAverage.txt)
[before_weightedAverage.txt](https://github.com/caio/go-tdigest/files/2236025/before_weightedAverage.txt)
