### PR TITLE
Add TrimmedMean

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,19 +2,49 @@
 
 
 [[projects]]
+  digest = "1:cf63454c1e81409484ded047413228de0f7a3031f0fcd36d4e1db7620c3c7d1b"
   name = "github.com/leesper/go_rng"
   packages = ["."]
+  pruneopts = ""
   revision = "5344a9259b21627d94279721ab1f27eb029194e7"
 
 [[projects]]
+  digest = "1:ba1b34793902651895b9cd923ea833010bd1497b1bf24f0a65b98db1078475c9"
   name = "github.com/yourbasic/fenwick"
   packages = ["."]
+  pruneopts = ""
   revision = "7cb325001daae879940edf7b19da8557a51ca5f7"
   version = "1.2.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:ad6d9b2cce40c7c44952d49a6a324a2110db43b4279d9e599db74e45de5ae80c"
+  name = "gonum.org/v1/gonum"
+  packages = [
+    "blas",
+    "blas/blas64",
+    "blas/gonum",
+    "floats",
+    "internal/asm/c128",
+    "internal/asm/f32",
+    "internal/asm/f64",
+    "internal/math32",
+    "lapack",
+    "lapack/gonum",
+    "lapack/lapack64",
+    "mat",
+    "stat",
+  ]
+  pruneopts = ""
+  revision = "f0982070f509ee139841ca385c44dc22a77c8da8"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "eac5a7bc22a9b8d592de2752be2ab1f8707df0caf1a1e77087c88671cbb8c94d"
+  input-imports = [
+    "github.com/leesper/go_rng",
+    "github.com/yourbasic/fenwick",
+    "gonum.org/v1/gonum/stat",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
This adds truncated / trimmed mean support - https://en.wikipedia.org/wiki/Truncated_mean. Originally the algorithm was based on [Python](https://github.com/CamDavidsonPilon/tdigest) version, but I've ended up rewriting it since it produced [negative means](https://github.com/CamDavidsonPilon/tdigest/issues/45).