### PR TITLE
Use rand.Perm to shuffle data

### DIFF
--- a/rng.go
+++ b/rng.go
@@ -9,6 +9,7 @@ import (
 type RNG interface {
 	Float32() float32
 	Intn(int) int
+	Perm(n int) []int
 }
 
 type globalRNG struct{}
@@ -19,6 +20,10 @@ func (r *globalRNG) Float32() float32 {
 
 func (r *globalRNG) Intn(i int) int {
 	return rand.Intn(i)
+}
+
+func (r *globalRNG) Perm(n int) []int {
+	return rand.Perm(n)
 }
 
 type localRNG struct {
@@ -37,4 +42,8 @@ func (r *localRNG) Float32() float32 {
 
 func (r *localRNG) Intn(i int) int {
 	return r.localRand.Intn(i)
+}
+
+func (r *localRNG) Perm(n int) []int {
+	return rand.Perm(n)
 }

--- a/summary.go
+++ b/summary.go
@@ -3,6 +3,7 @@ package tdigest
 import (
 	"fmt"
 	"math"
+	"math/rand"
 	"sort"
 )
 
@@ -159,6 +160,24 @@ func (s *summary) Clone() *summary {
 		means:  append([]float64{}, s.means...),
 		counts: append([]uint32{}, s.counts...),
 	}
+}
+
+// Randomly shuffles summary contents, so they can be added to another summary
+// with being pathological. Renders summary invalid.
+func (s *summary) shuffle(rng RNG) {
+	for i := len(s.means) - 1; i > 1; i-- {
+		s.Swap(i, rand.Intn(i+1))
+	}
+}
+
+// for sort.Interface
+func (s *summary) Swap(i, j int) {
+	s.means[i], s.means[j] = s.means[j], s.means[i]
+	s.counts[i], s.counts[j] = s.counts[j], s.counts[i]
+}
+
+func (s *summary) Less(i, j int) bool {
+	return s.means[i] < s.means[j]
 }
 
 // A simple loop unroll saves a surprising amount of time.

--- a/summary_test.go
+++ b/summary_test.go
@@ -62,7 +62,7 @@ func TestCore(t *testing.T) {
 	}
 
 	for k, v := range testData {
-		i := s.FindIndex(k)
+		i := s.findIndex(k)
 
 		if i == s.Len() {
 			t.Errorf("Couldn't find previously added key on summary")

--- a/tdigest_test.go
+++ b/tdigest_test.go
@@ -298,7 +298,15 @@ func quantile(q float64, data []float64) float64 {
 	return data[int(index)+1]*(index-float64(int(index))) + data[int(index)]*(float64(int(index)+1)-index)
 }
 
-func TestMerge(t *testing.T) {
+func TestMergeNormal(t *testing.T) {
+	testMerge(t, false)
+}
+
+func TestMergeDescructive(t *testing.T) {
+	testMerge(t, true)
+}
+
+func testMerge(t *testing.T, destructive bool) {
 	if testing.Short() {
 		t.Skipf("Skipping merge test. Short flag is on")
 	}
@@ -326,7 +334,12 @@ func TestMerge(t *testing.T) {
 
 		dist2 := uncheckedNew()
 		for i := 0; i < numSubs; i++ {
-			_ = dist2.Merge(subs[i])
+			if destructive {
+				_ = dist2.MergeDestructive(subs[i])
+			} else {
+				_ = dist2.Merge(subs[i])
+			}
+
 		}
 
 		if dist.Count() != dist2.Count() {


### PR DESCRIPTION
The idea is the same as in honeycomb's MergeDestructive - shuffle the data in-place without creating temporal summary. This version uses `rand.Perm` to achieve that.

```
benchmark                                         old ns/op     new ns/op     delta
BenchmarkTDigestMerge/compression=1_n=1-4         3003          3454          +15.02%
BenchmarkTDigestMerge/compression=1_n=10-4        22186         17029         -23.24%
BenchmarkTDigestMerge/compression=1_n=100-4       192510        156827        -18.54%
BenchmarkTDigestMerge/compression=10_n=1-4        27901         19703         -29.38%
BenchmarkTDigestMerge/compression=10_n=10-4       182637        142998        -21.70%
BenchmarkTDigestMerge/compression=10_n=100-4      1609905       1389554       -13.69%
BenchmarkTDigestMerge/compression=20_n=1-4        64749         45925         -29.07%
BenchmarkTDigestMerge/compression=20_n=10-4       394181        311002        -21.10%
BenchmarkTDigestMerge/compression=20_n=100-4      3527811       3053645       -13.44%
BenchmarkTDigestMerge/compression=30_n=1-4        102763        78263         -23.84%
BenchmarkTDigestMerge/compression=30_n=10-4       613174        561055        -8.50%
BenchmarkTDigestMerge/compression=30_n=100-4      5467320       5042737       -7.77%
BenchmarkTDigestMerge/compression=50_n=1-4        191938        152864        -20.36%
BenchmarkTDigestMerge/compression=50_n=10-4       1125494       1026854       -8.76%
BenchmarkTDigestMerge/compression=50_n=100-4      10034623      9390289       -6.42%
BenchmarkTDigestMerge/compression=100_n=1-4       445269        416063        -6.56%
BenchmarkTDigestMerge/compression=100_n=10-4      2727377       2578484       -5.46%
BenchmarkTDigestMerge/compression=100_n=100-4     25377255      23337689      -8.04%

benchmark                                         old allocs     new allocs     delta
BenchmarkTDigestMerge/compression=1_n=1-4         10             10             +0.00%
BenchmarkTDigestMerge/compression=1_n=10-4        29             20             -31.03%
BenchmarkTDigestMerge/compression=1_n=100-4       209            116            -44.50%
BenchmarkTDigestMerge/compression=10_n=1-4        10             10             +0.00%
BenchmarkTDigestMerge/compression=10_n=10-4       28             19             -32.14%
BenchmarkTDigestMerge/compression=10_n=100-4      210            111            -47.14%
BenchmarkTDigestMerge/compression=20_n=1-4        10             10             +0.00%
BenchmarkTDigestMerge/compression=20_n=10-4       28             19             -32.14%
BenchmarkTDigestMerge/compression=20_n=100-4      210            111            -47.14%
BenchmarkTDigestMerge/compression=30_n=1-4        10             10             +0.00%
BenchmarkTDigestMerge/compression=30_n=10-4       28             19             -32.14%
BenchmarkTDigestMerge/compression=30_n=100-4      210            111            -47.14%
BenchmarkTDigestMerge/compression=50_n=1-4        10             10             +0.00%
BenchmarkTDigestMerge/compression=50_n=10-4       28             19             -32.14%
BenchmarkTDigestMerge/compression=50_n=100-4      210            111            -47.14%
BenchmarkTDigestMerge/compression=100_n=1-4       10             10             +0.00%
BenchmarkTDigestMerge/compression=100_n=10-4      28             19             -32.14%
BenchmarkTDigestMerge/compression=100_n=100-4     210            111            -47.14%

benchmark                                         old bytes     new bytes     delta
BenchmarkTDigestMerge/compression=1_n=1-4         495           596           +20.40%
BenchmarkTDigestMerge/compression=1_n=10-4        1772          1469          -17.10%
BenchmarkTDigestMerge/compression=1_n=100-4       11872         8695          -26.76%
BenchmarkTDigestMerge/compression=10_n=1-4        2776          3623          +30.51%
BenchmarkTDigestMerge/compression=10_n=10-4       9682          8196          -15.35%
BenchmarkTDigestMerge/compression=10_n=100-4      76792         54860         -28.56%
BenchmarkTDigestMerge/compression=20_n=1-4        5536          7209          +30.22%
BenchmarkTDigestMerge/compression=20_n=10-4       19166         16160         -15.68%
BenchmarkTDigestMerge/compression=20_n=100-4      153729        108539        -29.40%
BenchmarkTDigestMerge/compression=30_n=1-4        7970          10657         +33.71%
BenchmarkTDigestMerge/compression=30_n=10-4       28128         24432         -13.14%
BenchmarkTDigestMerge/compression=30_n=100-4      226685        159116        -29.81%
BenchmarkTDigestMerge/compression=50_n=1-4        12783         16748         +31.02%
BenchmarkTDigestMerge/compression=50_n=10-4       46111         39512         -14.31%
BenchmarkTDigestMerge/compression=50_n=100-4      373601        264224        -29.28%
BenchmarkTDigestMerge/compression=100_n=1-4       25697         33696         +31.13%
BenchmarkTDigestMerge/compression=100_n=10-4      94255         79988         -15.14%
BenchmarkTDigestMerge/compression=100_n=100-4     768160        545184        -29.03%
```