### PR TITLE
Add TDigest.FromBytes and cleanup RNG interface

### DIFF
--- a/options_test.go
+++ b/options_test.go
@@ -37,7 +37,8 @@ func TestRandomNumberGenerator(t *testing.T) {
 	// So that they should emit the same values when called
 	// at the same frequency
 	for i := 0; i < numTests; i++ {
-		if t1.rng.Float32() != t2.rng.Float32() || t1.rng.Intn(10) != t2.rng.Intn(10) {
+		if t1.rng.Float32() != t2.rng.Float32() ||
+			t1.rng.Intn(10) != t2.rng.Intn(10) {
 			t.Errorf("r1 and r2 should be distinct RNGs returning the same values")
 		}
 	}

--- a/rng.go
+++ b/rng.go
@@ -9,21 +9,16 @@ import (
 type RNG interface {
 	Float32() float32
 	Intn(int) int
-	Perm(n int) []int
 }
 
 type globalRNG struct{}
 
-func (r *globalRNG) Float32() float32 {
+func (r globalRNG) Float32() float32 {
 	return rand.Float32()
 }
 
-func (r *globalRNG) Intn(i int) int {
+func (r globalRNG) Intn(i int) int {
 	return rand.Intn(i)
-}
-
-func (r *globalRNG) Perm(n int) []int {
-	return rand.Perm(n)
 }
 
 type localRNG struct {
@@ -42,8 +37,4 @@ func (r *localRNG) Float32() float32 {
 
 func (r *localRNG) Intn(i int) int {
 	return r.localRand.Intn(i)
-}
-
-func (r *localRNG) Perm(n int) []int {
-	return rand.Perm(n)
 }

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -33,10 +33,24 @@ func TestSerialization(t *testing.T) {
 
 	serialized, _ := t1.AsBytes()
 
-	t2, _ := FromBytes(bytes.NewReader(serialized))
+	t2, err := FromBytes(bytes.NewReader(serialized))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertEqual(t, t1, t2)
 
-	if t1.Count() != t2.Count() || t1.summary.Len() != t2.summary.Len() || t1.compression != t2.compression {
-		t.Errorf("Deserialized to something different. t1=%v t2=%v serialized=%v", t1, t2, serialized)
+	err = t2.FromBytes(serialized)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertEqual(t, t1, t2)
+}
+
+func assertEqual(t *testing.T, t1, t2 *TDigest) {
+	if t1.Count() != t2.Count() ||
+		t1.summary.Len() != t2.summary.Len() ||
+		t1.compression != t2.compression {
+		t.Errorf("Deserialized to something different. t1=%v t2=%v", t1, t2)
 	}
 }
 

--- a/summary.go
+++ b/summary.go
@@ -3,7 +3,6 @@ package tdigest
 import (
 	"fmt"
 	"math"
-	"math/rand"
 	"sort"
 )
 
@@ -148,7 +147,7 @@ func (s *summary) ForEach(f func(float64, uint32) bool) {
 }
 
 func (s *summary) Perm(rng RNG, f func(float64, uint32) bool) {
-	for _, i := range rng.Perm(s.Len()) {
+	for _, i := range perm(rng, s.Len()) {
 		if !f(s.means[i], s.counts[i]) {
 			break
 		}
@@ -166,7 +165,7 @@ func (s *summary) Clone() *summary {
 // with being pathological. Renders summary invalid.
 func (s *summary) shuffle(rng RNG) {
 	for i := len(s.means) - 1; i > 1; i-- {
-		s.Swap(i, rand.Intn(i+1))
+		s.Swap(i, rng.Intn(i+1))
 	}
 }
 
@@ -194,4 +193,14 @@ func sumUntilIndex(s []uint32, idx int) uint64 {
 		cumSum += uint64(s[i])
 	}
 	return cumSum
+}
+
+func perm(rng RNG, n int) []int {
+	m := make([]int, n)
+	for i := 1; i < n; i++ {
+		j := rng.Intn(i + 1)
+		m[i] = m[j]
+		m[j] = i
+	}
+	return m
 }

--- a/tdigest.go
+++ b/tdigest.go
@@ -43,7 +43,7 @@ func New(options ...tdigestOption) (*TDigest, error) {
 	tdigest := &TDigest{
 		compression: 100,
 		count:       0,
-		rng:         &globalRNG{},
+		rng:         globalRNG{},
 	}
 
 	for _, option := range options {

--- a/tdigest_test.go
+++ b/tdigest_test.go
@@ -514,7 +514,7 @@ func TestCDFInsideLastCentroid(t *testing.T) {
 		},
 		compression: 5,
 		count:       1250,
-		rng:         &globalRNG{},
+		rng:         globalRNG{},
 	}
 
 	if cdf := td.CDF(7.144560976650238e+06); cdf > 1 {


### PR DESCRIPTION
FromBytes is copied from github.com/honeycombio/go-tdigest. I also remove `Perm` func added in previous PR from `RNG` so interface is small and it is easier to swap random number generator.