### PR TITLE
Add sumCache

### DIFF
--- a/summary_test.go
+++ b/summary_test.go
@@ -141,10 +141,10 @@ func TestFloorSum(t *testing.T) {
 	for i := float64(0); i < float64(total)+10; i++ {
 		node, _ := s.FloorSum(i)
 		if s.HeadSum(node) > i {
-			t.Errorf("headSum(%d)=%.0f (>%.0f)", node, s.HeadSum(node), i)
+			t.Fatalf("headSum(%d)=%.0f (>%.0f)", node, s.HeadSum(node), i)
 		}
 		if node+1 < s.Len() && s.HeadSum(node+1) <= i {
-			t.Errorf("headSum(%d)=%.0f (>%.0f)", node+1, s.HeadSum(node+1), i)
+			t.Fatalf("headSum(%d)=%.0f (>%.0f)", node+1, s.HeadSum(node+1), i)
 		}
 	}
 }
@@ -189,5 +189,61 @@ func TestAdjustLeftRight(t *testing.T) {
 
 	if !sort.Float64sAreSorted(s.means) || s.counts[4] != 4 {
 		t.Errorf("adjustLeft should have fixed the keys/counts state. %v %v", s.means, s.counts)
+	}
+}
+
+var sumCacheTests = []struct {
+	until int
+	idx   int
+	sum   uint64
+}{
+	{0, 0, 0},
+	{1, 0, 0},
+	{2, 0, 0},
+	{3, 0, 0},
+	{4, 4, 4},
+	{5, 4, 4},
+	{6, 4, 4},
+	{7, 4, 4},
+	{8, 8, 8},
+	{9, 8, 8},
+}
+
+func TestSumCache(t *testing.T) {
+	s := newSumCache(100)
+	for i := 0; i < 100; i++ {
+		if i%4 == 0 {
+			s.Set(i, uint64(i))
+		}
+	}
+
+	for i, test := range sumCacheTests {
+		idx, sum := s.Get(test.until)
+		if idx != test.idx {
+			t.Fatalf("#%d got idx=%d, wanted %d", i, idx, test.idx)
+		}
+		if sum != test.sum {
+			t.Fatalf("#%d got sum=%d, wanted %d", i, sum, test.sum)
+		}
+	}
+
+	s.Invalidate(10)
+	idx, sum := s.Get(10)
+	if idx != 4 {
+		t.Fatalf("got idx=%d, wanted %d", idx, 4)
+	}
+	if sum != 4 {
+		t.Fatalf("got sum=%d, wanted %d", sum, 4)
+	}
+
+	s.Invalidate(0)
+	for i := 0; i < 100; i++ {
+		idx, sum := s.Get(i)
+		if idx != 0 {
+			t.Fatalf("got idx=%d, wanted %d", idx, 0)
+		}
+		if sum != 0 {
+			t.Fatalf("got sum=%d, wanted %d", sum, 0)
+		}
 	}
 }

--- a/tdigest_test.go
+++ b/tdigest_test.go
@@ -783,52 +783,6 @@ func randomTDigest(compression uint32) *TDigest {
 	return t
 }
 
-var sumSizes = []int{10, 100, 1000, 10000}
-
-func BenchmarkSumLoopSimple(b *testing.B) {
-	for _, size := range sumSizes {
-		size := size
-		b.Run(fmt.Sprint(size), func(b *testing.B) {
-			benchmarkSumLoopSimple(b, size)
-		})
-	}
-}
-
-func benchmarkSumLoopSimple(b *testing.B, size int) {
-	counts := generateCounts(size)
-	indexes := generateIndexes(size)
-
-	b.ReportAllocs()
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		for _, idx := range indexes {
-			_ = sumUntilIndexSimple(counts, idx)
-		}
-	}
-}
-
-func BenchmarkSumLoopUnrolled(b *testing.B) {
-	for _, size := range sumSizes {
-		size := size
-		b.Run(fmt.Sprint(size), func(b *testing.B) {
-			benchmarkSumLoopUnrolled(b, size)
-		})
-	}
-}
-
-func benchmarkSumLoopUnrolled(b *testing.B, size int) {
-	counts := generateCounts(size)
-	indexes := generateIndexes(size)
-
-	b.ReportAllocs()
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		for _, idx := range indexes {
-			_ = sumUntilIndex(counts, idx)
-		}
-	}
-}
-
 func generateCounts(size int) []uint32 {
 	counts := make([]uint32, size)
 	for i := 0; i < size; i++ {


### PR DESCRIPTION
This is my attempt to speedup `HeadSum` by caching results for every 4th index. The speedup is moderate but measurable for big tdigests / number of iterations.

```
benchmark                                              old ns/op     new ns/op     delta
BenchmarkTDigestAddMulti/compression=1_n=10-4          1102          1098          -0.36%
BenchmarkTDigestAddMulti/compression=1_n=100-4         11388         11669         +2.47%
BenchmarkTDigestAddMulti/compression=1_n=1000-4        130596        127549        -2.33%
BenchmarkTDigestAddMulti/compression=1_n=10000-4       1237468       1261566       +1.95%
BenchmarkTDigestAddMulti/compression=10_n=10-4         1413          1441          +1.98%
BenchmarkTDigestAddMulti/compression=10_n=100-4        12918         12836         -0.63%
BenchmarkTDigestAddMulti/compression=10_n=1000-4       153696        165558        +7.72%
BenchmarkTDigestAddMulti/compression=10_n=10000-4      1734227       1710359       -1.38%
BenchmarkTDigestAddMulti/compression=20_n=10-4         1708          1778          +4.10%
BenchmarkTDigestAddMulti/compression=20_n=100-4        14475         15097         +4.30%
BenchmarkTDigestAddMulti/compression=20_n=1000-4       189931        178561        -5.99%
BenchmarkTDigestAddMulti/compression=20_n=10000-4      2193921       1845242       -15.89%
BenchmarkTDigestAddMulti/compression=30_n=10-4         2146          2110          -1.68%
BenchmarkTDigestAddMulti/compression=30_n=100-4        15794         17179         +8.77%
BenchmarkTDigestAddMulti/compression=30_n=1000-4       211951        201384        -4.99%
BenchmarkTDigestAddMulti/compression=30_n=10000-4      2398210       2093405       -12.71%
BenchmarkTDigestAddMulti/compression=50_n=10-4         2563          2531          -1.25%
BenchmarkTDigestAddMulti/compression=50_n=100-4        17855         19061         +6.75%
BenchmarkTDigestAddMulti/compression=50_n=1000-4       255795        232520        -9.10%
BenchmarkTDigestAddMulti/compression=50_n=10000-4      2654810       2135383       -19.57%
BenchmarkTDigestAddMulti/compression=100_n=10-4        3647          3662          +0.41%
BenchmarkTDigestAddMulti/compression=100_n=100-4       22421         24263         +8.22%
BenchmarkTDigestAddMulti/compression=100_n=1000-4      317849        303317        -4.57%
BenchmarkTDigestAddMulti/compression=100_n=10000-4     3242118       2419567       -25.37%
BenchmarkTDigestMerge/compression=1_n=1-4              2619          2292          -12.49%
BenchmarkTDigestMerge/compression=1_n=10-4             18852         18030         -4.36%
BenchmarkTDigestMerge/compression=1_n=100-4            163565        159052        -2.76%
BenchmarkTDigestMerge/compression=10_n=1-4             23780         20716         -12.88%
BenchmarkTDigestMerge/compression=10_n=10-4            146508        159361        +8.77%
BenchmarkTDigestMerge/compression=10_n=100-4           1385307       1339214       -3.33%
BenchmarkTDigestMerge/compression=20_n=1-4             50596         48907         -3.34%
BenchmarkTDigestMerge/compression=20_n=10-4            339448        302352        -10.93%
BenchmarkTDigestMerge/compression=20_n=100-4           3218146       2781759       -13.56%
BenchmarkTDigestMerge/compression=30_n=1-4             88794         80192         -9.69%
BenchmarkTDigestMerge/compression=30_n=10-4            582997        484988        -16.81%
BenchmarkTDigestMerge/compression=30_n=100-4           5177174       4228477       -18.32%
BenchmarkTDigestMerge/compression=50_n=1-4             164685        155777        -5.41%
BenchmarkTDigestMerge/compression=50_n=10-4            1067487       921889        -13.64%
BenchmarkTDigestMerge/compression=50_n=100-4           9690776       7439829       -23.23%
BenchmarkTDigestMerge/compression=100_n=1-4            417172        420961        +0.91%
BenchmarkTDigestMerge/compression=100_n=10-4           2610859       2104957       -19.38%
BenchmarkTDigestMerge/compression=100_n=100-4          24411581      16249783      -33.43%

benchmark                                              old allocs     new allocs     delta
BenchmarkTDigestAddMulti/compression=1_n=10-4          5              5              +0.00%
BenchmarkTDigestAddMulti/compression=1_n=100-4         7              7              +0.00%
BenchmarkTDigestAddMulti/compression=1_n=1000-4        12             12             +0.00%
BenchmarkTDigestAddMulti/compression=1_n=10000-4       14             17             +21.43%
BenchmarkTDigestAddMulti/compression=10_n=10-4         5              5              +0.00%
BenchmarkTDigestAddMulti/compression=10_n=100-4        5              5              +0.00%
BenchmarkTDigestAddMulti/compression=10_n=1000-4       5              5              +0.00%
BenchmarkTDigestAddMulti/compression=10_n=10000-4      7              9              +28.57%
BenchmarkTDigestAddMulti/compression=20_n=10-4         5              5              +0.00%
BenchmarkTDigestAddMulti/compression=20_n=100-4        5              5              +0.00%
BenchmarkTDigestAddMulti/compression=20_n=1000-4       5              7              +40.00%
BenchmarkTDigestAddMulti/compression=20_n=10000-4      7              7              +0.00%
BenchmarkTDigestAddMulti/compression=30_n=10-4         5              5              +0.00%
BenchmarkTDigestAddMulti/compression=30_n=100-4        5              5              +0.00%
BenchmarkTDigestAddMulti/compression=30_n=1000-4       5              7              +40.00%
BenchmarkTDigestAddMulti/compression=30_n=10000-4      5              7              +40.00%
BenchmarkTDigestAddMulti/compression=50_n=10-4         5              5              +0.00%
BenchmarkTDigestAddMulti/compression=50_n=100-4        5              5              +0.00%
BenchmarkTDigestAddMulti/compression=50_n=1000-4       5              7              +40.00%
BenchmarkTDigestAddMulti/compression=50_n=10000-4      5              7              +40.00%
BenchmarkTDigestAddMulti/compression=100_n=10-4        5              5              +0.00%
BenchmarkTDigestAddMulti/compression=100_n=100-4       5              5              +0.00%
BenchmarkTDigestAddMulti/compression=100_n=1000-4      5              7              +40.00%
BenchmarkTDigestAddMulti/compression=100_n=10000-4     5              7              +40.00%
BenchmarkTDigestMerge/compression=1_n=1-4              9              9              +0.00%
BenchmarkTDigestMerge/compression=1_n=10-4             20             19             -5.00%
BenchmarkTDigestMerge/compression=1_n=100-4            115            110            -4.35%
BenchmarkTDigestMerge/compression=10_n=1-4             9              9              +0.00%
BenchmarkTDigestMerge/compression=10_n=10-4            18             18             +0.00%
BenchmarkTDigestMerge/compression=10_n=100-4           110            112            +1.82%
BenchmarkTDigestMerge/compression=20_n=1-4             9              9              +0.00%
BenchmarkTDigestMerge/compression=20_n=10-4            18             22             +22.22%
BenchmarkTDigestMerge/compression=20_n=100-4           110            112            +1.82%
BenchmarkTDigestMerge/compression=30_n=1-4             9              13             +44.44%
BenchmarkTDigestMerge/compression=30_n=10-4            18             22             +22.22%
BenchmarkTDigestMerge/compression=30_n=100-4           110            112            +1.82%
BenchmarkTDigestMerge/compression=50_n=1-4             9              13             +44.44%
BenchmarkTDigestMerge/compression=50_n=10-4            18             22             +22.22%
BenchmarkTDigestMerge/compression=50_n=100-4           110            112            +1.82%
BenchmarkTDigestMerge/compression=100_n=1-4            9              13             +44.44%
BenchmarkTDigestMerge/compression=100_n=10-4           18             22             +22.22%
BenchmarkTDigestMerge/compression=100_n=100-4          110            112            +1.82%

benchmark                                              old bytes     new bytes     delta
BenchmarkTDigestAddMulti/compression=1_n=10-4          240           256           +6.67%
BenchmarkTDigestAddMulti/compression=1_n=100-4         480           496           +3.33%
BenchmarkTDigestAddMulti/compression=1_n=1000-4        1239          1267          +2.26%
BenchmarkTDigestAddMulti/compression=1_n=10000-4       1481          1858          +25.46%
BenchmarkTDigestAddMulti/compression=10_n=10-4         1424          1440          +1.12%
BenchmarkTDigestAddMulti/compression=10_n=100-4        1424          1440          +1.12%
BenchmarkTDigestAddMulti/compression=10_n=1000-4       1424          1440          +1.12%
BenchmarkTDigestAddMulti/compression=10_n=10000-4      4112          4608          +12.06%
BenchmarkTDigestAddMulti/compression=20_n=10-4         2800          2816          +0.57%
BenchmarkTDigestAddMulti/compression=20_n=100-4        2800          2816          +0.57%
BenchmarkTDigestAddMulti/compression=20_n=1000-4       2800          3264          +16.57%
BenchmarkTDigestAddMulti/compression=20_n=10000-4      7792          3264          -58.11%
BenchmarkTDigestAddMulti/compression=30_n=10-4         4080          4096          +0.39%
BenchmarkTDigestAddMulti/compression=30_n=100-4        4080          4096          +0.39%
BenchmarkTDigestAddMulti/compression=30_n=1000-4       4080          4768          +16.86%
BenchmarkTDigestAddMulti/compression=30_n=10000-4      4080          4768          +16.86%
BenchmarkTDigestAddMulti/compression=50_n=10-4         6256          6272          +0.26%
BenchmarkTDigestAddMulti/compression=50_n=100-4        6256          6272          +0.26%
BenchmarkTDigestAddMulti/compression=50_n=1000-4       6256          7328          +17.14%
BenchmarkTDigestAddMulti/compression=50_n=10000-4      6256          7328          +17.14%
BenchmarkTDigestAddMulti/compression=100_n=10-4        12400         12416         +0.13%
BenchmarkTDigestAddMulti/compression=100_n=100-4       12400         12416         +0.13%
BenchmarkTDigestAddMulti/compression=100_n=1000-4      12400         14496         +16.90%
BenchmarkTDigestAddMulti/compression=100_n=10000-4     12400         14496         +16.90%
BenchmarkTDigestMerge/compression=1_n=1-4              496           512           +3.23%
BenchmarkTDigestMerge/compression=1_n=10-4             1417          1384          -2.33%
BenchmarkTDigestMerge/compression=1_n=100-4            8719          7957          -8.74%
BenchmarkTDigestMerge/compression=10_n=1-4             3360          3264          -2.86%
BenchmarkTDigestMerge/compression=10_n=10-4            7552          7616          +0.85%
BenchmarkTDigestMerge/compression=10_n=100-4           54062         53472         -1.09%
BenchmarkTDigestMerge/compression=20_n=1-4             6560          6464          -1.46%
BenchmarkTDigestMerge/compression=20_n=10-4            15264         15680         +2.73%
BenchmarkTDigestMerge/compression=20_n=100-4           107424        98880         -7.95%
BenchmarkTDigestMerge/compression=30_n=1-4             9632          10752         +11.63%
BenchmarkTDigestMerge/compression=30_n=10-4            22048         22656         +2.76%
BenchmarkTDigestMerge/compression=30_n=100-4           155552        141440        -9.07%
BenchmarkTDigestMerge/compression=50_n=1-4             14752         16640         +12.80%
BenchmarkTDigestMerge/compression=50_n=10-4            35872         37760         +5.26%
BenchmarkTDigestMerge/compression=50_n=100-4           258336        242176        -6.26%
BenchmarkTDigestMerge/compression=100_n=1-4            29600         33792         +14.16%
BenchmarkTDigestMerge/compression=100_n=10-4           73376         77568         +5.71%
BenchmarkTDigestMerge/compression=100_n=100-4          535712        513792        -4.09%
```