### PR TITLE
go tdigest: only create a newLocalRNG if one is not provided by options

### DIFF
--- a/tdigest.go
+++ b/tdigest.go
@@ -55,7 +55,6 @@ func newWithoutSummary(options ...tdigestOption) (*TDigest, error) {
 	tdigest := &TDigest{
 		compression: 100,
 		count:       0,
-		rng:         newLocalRNG(1),
 	}
 
 	for _, option := range options {
@@ -63,6 +62,10 @@ func newWithoutSummary(options ...tdigestOption) (*TDigest, error) {
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if tdigest.rng == nil {
+		tdigest.rng = newLocalRNG(1)
 	}
 
 	return tdigest, nil


### PR DESCRIPTION
Allocating and seeding rand objects can be a surprisingly expensive operation.

Especially if the user is already re-using RNGs, or needs to generate their own for whatever reason, this extra setup can be a lot of overhead for an object that does not get used.

<img width="616" alt="Screen Shot 2022-10-07 at 1 46 15 PM" src="https://user-images.githubusercontent.com/13932684/194650220-b83d3770-48e1-41a6-92e4-ea1712cfe927.png">